### PR TITLE
Henry | Fix append of macbook information object inside an array

### DIFF
--- a/system_information.sh
+++ b/system_information.sh
@@ -24,41 +24,51 @@ create_or_update_json() {
     local screen_size="$3"
     local chip_type="$4"
     local status="$5"  # New argument for status
-    local json_file="mac_info.json"
+    local json_file="../../TXT/script/mac_info.json"
+    local data=""
 
+   
     # Check if JSON file exists
     if [ -f "$json_file" ]; then
-        # If it exists, load the existing data
-        data=$(< "$json_file")
-    else
-        data="[]"
+        # Check if the JSON file has content
+        if [ -s "$json_file" ]; then
+            # If it exists and has content, load the existing data
+            data=$(< "$json_file")
+        else
+            # If it exists but has no content, initialize with an empty JSON array
+            data="[]"
+        fi
     fi
-
-    # Check for duplicate serial numbers
+    # Check for duplicate serial numbers to not append any unnessary data we have
     duplicate=$(echo "$data" | grep "\"serial_number\": \"$serial_number\"")
     if [ -n "$duplicate" ]; then
         echo "Duplicate serial number found. Skipping..."
         return
     fi
 
-    # Add new MacBook information
+    # Create a stringified json so we could put it easily in a file that reads different sequences like quotations for properties
     new_macbook_info="{\"laptop_number\": \"no number\", \"serial_number\": \"$serial_number\", \"model_date\": \"$model_year\", \"screen_size\": \"$screen_size\",  \"chip\": \"$chip_type\", \"status\": \"$status\"}"
     new_macbook_info=$(echo "$new_macbook_info" | cut -c 1-)
 
     # If the data is not empty, add a comma before appending new data
+    data_length=${#data}
     if [ "${data}" != "[]" ]; then
-        data="${data},"
+       data="${data%?}" # Cut the ending piece of the array to append to the object instead of array
+       data="${data},${new_macbook_info},]" # Append to the previous object and add the array ending
+
+    else # Creating our first object
+        
+        data=$(echo "${data}" | cut -c 1-$((data_length - 1)))
+        data="${data}${new_macbook_info},]"
+
     fi
-
-    # Append the new MacBook information
-    data="${data}${new_macbook_info}"
-
+    
     # Write data to JSON file
-    echo "[$data]" > "$json_file"
+    echo "$data" > "$json_file"
     echo "JSON file updated successfully."
 }
 
-
+# TODO: Issue with smaller macbook screens
 get_screen_size() {
     model_name=$(sysctl hw.model | awk -F '[:,]' '{print $2}' | tr -d ' ')
     serial_number=$(system_profiler SPHardwareDataType | awk '/Serial/ {print $4}' | cut -c 9-)


### PR DESCRIPTION
Prior, it kept creating a new array for every object, causing nested arrays and an unnessesary initial array

Fix includes:
- Appending to previous object inside the array
- Initial array with our first object afterwards containing macbook information
- Add comments to indicate why we added cuts for certain strings

next steps: Fix bug on smaller screens on macbooks within 2020 year